### PR TITLE
Expose setter

### DIFF
--- a/src/metadata/directory_metadata.rs
+++ b/src/metadata/directory_metadata.rs
@@ -109,6 +109,11 @@ impl DirectoryMetadata {
         self.name = name;
     }
 
+    /// Set time of creation
+    pub fn set_created_time(&mut self, created_time: ::time::Tm) {
+        self.created_time = created_time;
+    }
+
     /// Set time of modification
     pub fn set_modified_time(&mut self, modified_time: ::time::Tm) {
         self.modified_time = modified_time

--- a/src/metadata/directory_metadata.rs
+++ b/src/metadata/directory_metadata.rs
@@ -114,9 +114,14 @@ impl DirectoryMetadata {
         self.modified_time = modified_time
     }
 
-    /// User setteble metadata for custom metadata
+    /// Setter for user_metadata
     pub fn set_user_metadata(&mut self, user_metadata: Vec<u8>) {
         self.user_metadata = user_metadata;
+    }
+
+    /// Setter for parent_dir_key
+    pub fn set_parent_dir_key(&mut self, parent_dir_key: Option<DirectoryKey>) {
+        self.parent_dir_key = parent_dir_key;
     }
 }
 


### PR DESCRIPTION
Expose setter for setting the parent directory key. This setter will be useful for updating the parent directory while moving/coping the directories.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_nfs/78)

<!-- Reviewable:end -->
